### PR TITLE
Fix JSX structure in FerryOrders component

### DIFF
--- a/src/components/FerryOrders.jsx
+++ b/src/components/FerryOrders.jsx
@@ -117,9 +117,6 @@ const [useCrossDateFilter, setUseCrossDateFilter] = useState(false);
 
   return (
     <div className="p-4 pt-0">
-      <div className="flex justify-between items-center mb-2">
-        </div>
-      </div>
 
       <div className="flex gap-4 mb-4">
         <select
@@ -204,10 +201,14 @@ const [useCrossDateFilter, setUseCrossDateFilter] = useState(false);
         </table>
       </div>
       <div className="mt-4">
+        <button
+          onClick={() => {
             setEditIndex(null);
             setIsModalOpen(true);
           }}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
         >
+          Dodaj zamówienie
         </button>
       </div>
       {isModalOpen && (


### PR DESCRIPTION
## Summary
- clean up opening/closing tags in `FerryOrders.jsx`
- add missing button for opening the modal

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ef8c4388832fa14a80c76b076fa1